### PR TITLE
feat: add forgejo widget

### DIFF
--- a/docs/widgets/services/forgejo.md
+++ b/docs/widgets/services/forgejo.md
@@ -1,0 +1,17 @@
+---
+title: Forgejo
+description: Forgejo Widget Configuration
+---
+
+Learn more about [Forgejo](https://forgejo.org/).
+
+API token requires `notifications`, `repository` and `issue` permissions. See the [Forgejo documentation](https://forgejo.org/docs/latest/user/api-usage/) for details on generating tokens.
+
+Allowed fields: `["repositories", "notifications", "issues", "pulls"]`.
+
+```yaml
+widget:
+  type: forgejo
+  url: http://forgejo.host.or.ip:port
+  key: forgejoapitoken
+```

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -34,6 +34,7 @@ const components = {
   fileflows: dynamic(() => import("./fileflows/component")),
   firefly: dynamic(() => import("./firefly/component")),
   flood: dynamic(() => import("./flood/component")),
+  forgejo: dynamic(() => import("./forgejo/component")),
   freshrss: dynamic(() => import("./freshrss/component")),
   frigate: dynamic(() => import("./frigate/component")),
   fritzbox: dynamic(() => import("./fritzbox/component")),

--- a/src/widgets/forgejo/component.jsx
+++ b/src/widgets/forgejo/component.jsx
@@ -1,0 +1,38 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: forgejoNotifications, error: forgejoNotificationsError } = useWidgetAPI(widget, "notifications");
+  const { data: forgejoIssues, error: forgejoIssuesError } = useWidgetAPI(widget, "issues");
+  const { data: forgejoRepositories, error: forgejoRepositoriesError } = useWidgetAPI(widget, "repositories");
+
+  if (forgejoNotificationsError || forgejoIssuesError || forgejoRepositoriesError) {
+    return (
+      <Container service={service} error={forgejoNotificationsError ?? forgejoIssuesError ?? forgejoRepositoriesError} />
+    );
+  }
+
+  if (!forgejoNotifications || !forgejoIssues || !forgejoRepositories) {
+    return (
+      <Container service={service}>
+        <Block label="forgejo.notifications" />
+        <Block label="forgejo.issues" />
+        <Block label="forgejo.pulls" />
+        <Block label="forgejo.repositories" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="forgejo.notifications" value={forgejoNotifications.length} />
+      <Block label="forgejo.issues" value={forgejoIssues.issues.length} />
+      <Block label="forgejo.pulls" value={forgejoIssues.pulls.length} />
+      <Block label="forgejo.repositories" value={forgejoRepositories.data.length} />
+    </Container>
+  );
+}

--- a/src/widgets/forgejo/component.jsx
+++ b/src/widgets/forgejo/component.jsx
@@ -12,7 +12,10 @@ export default function Component({ service }) {
 
   if (forgejoNotificationsError || forgejoIssuesError || forgejoRepositoriesError) {
     return (
-      <Container service={service} error={forgejoNotificationsError ?? forgejoIssuesError ?? forgejoRepositoriesError} />
+      <Container
+        service={service}
+        error={forgejoNotificationsError ?? forgejoIssuesError ?? forgejoRepositoriesError}
+      />
     );
   }
 

--- a/src/widgets/forgejo/widget.js
+++ b/src/widgets/forgejo/widget.js
@@ -1,0 +1,25 @@
+import { asJson } from "utils/proxy/api-helpers";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    notifications: {
+      endpoint: "notifications",
+    },
+    issues: {
+      endpoint: "repos/issues/search",
+      map: (data) => ({
+        pulls: asJson(data).filter((issue) => issue.pull_request),
+        issues: asJson(data).filter((issue) => !issue.pull_request),
+      }),
+    },
+    repositories: {
+      endpoint: "repos/search",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -28,6 +28,7 @@ import evcc from "./evcc/widget";
 import fileflows from "./fileflows/widget";
 import firefly from "./firefly/widget";
 import flood from "./flood/widget";
+import forgejo from "./forgejo/widget";
 import freshrss from "./freshrss/widget";
 import frigate from "./frigate/widget";
 import fritzbox from "./fritzbox/widget";
@@ -169,6 +170,7 @@ const widgets = {
   fileflows,
   firefly,
   flood,
+  forgejo,
   freshrss,
   frigate,
   fritzbox,


### PR DESCRIPTION
This PR adds a widget for Forgejo. Although Forgejo is a fork of Gitea and the Gitea widget worked fine in that past things changed starting with Forgejo version 12.0. This version removed some authentication mechanisms rendering the Gitea widget non-functional for Forgejo. This widget addresses it making it working again for Forgejo.